### PR TITLE
[nightshift] ci-fixes: harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -5,9 +5,13 @@ on:
     - cron: "0 0 */2 * *" # Run every 2 days at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  ping:
+  keep-alive:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -16,12 +20,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Ping Upstash
+      - name: Keep Alive
         env:
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** ci-fixes
**Category:** pr
**Changes:**
- Added `permissions: contents: read` (least privilege for scheduled job)
- Renamed job `ping` → `keep-alive` (more accurate — script uses SET, not PING)
- Added `timeout-minutes: 5` to prevent runaway workflow runs
- Updated Python 3.11 → 3.12 (current stable)
- Added `cache: pip` for faster dependency installation
- Renamed step "Ping Upstash" → "Keep Alive" to match actual behavior

Merge if useful, close if not.